### PR TITLE
improve performance and readability

### DIFF
--- a/SQL/Select/Weather Observation Station 7.sql
+++ b/SQL/Select/Weather Observation Station 7.sql
@@ -19,4 +19,4 @@ Write a query to print the list of CITY that ends at vowels in lexicographical o
 
 SELECT DISTINCT CITY 
 FROM STATION 
-WHERE CITY LIKE '%a' OR CITY LIKE '%e' OR CITY LIKE '%i' OR  CITY LIKE '%o' OR CITY LIKE '%u';
+WHERE RIGHT(CITY, 1) IN ('a', 'e', 'i', 'o', 'u');


### PR DESCRIPTION
Using `RIGHT` function instead of `LIKE` can improve the performance in some cases and makes the SQL code more readable.